### PR TITLE
Slim down Affine size

### DIFF
--- a/affine.ts
+++ b/affine.ts
@@ -57,7 +57,8 @@ namespace microcode {
         }
 
         private computeWorldPos(): Vec2 {
-            const pos = this.localPos_
+            const pos = new Vec2()
+            pos.copyFrom(this.localPos_)
             let parent = this.parent_
             while (parent) {
                 Vec2.TranslateToRef(pos, parent.localPos, pos)

--- a/editor.ts
+++ b/editor.ts
@@ -202,6 +202,11 @@ namespace microcode {
                 return
             }
 
+            if (target.xfrm.root === this.hudroot.xfrm) {
+                this.moveTo(target)
+                return
+            }
+
             const occBounds = new Bounds({
                 left: Screen.LEFT_EDGE,
                 top: Screen.TOP_EDGE + TOOLBAR_HEIGHT + TOOLBAR_MARGIN,

--- a/editor.ts
+++ b/editor.ts
@@ -202,11 +202,6 @@ namespace microcode {
                 return
             }
 
-            if (target.rootXfrm.tag === "hud") {
-                this.moveTo(target)
-                return
-            }
-
             const occBounds = new Bounds({
                 left: Screen.LEFT_EDGE,
                 top: Screen.TOP_EDGE + TOOLBAR_HEIGHT + TOOLBAR_MARGIN,
@@ -259,7 +254,6 @@ namespace microcode {
                 )
             this.hudroot = new Placeable()
             this.hudroot.xfrm.localPos = new Vec2(0, Screen.TOP_EDGE)
-            this.hudroot.xfrm.tag = "hud"
             this.scrollroot = new Placeable()
             this.scrollroot.xfrm.localPos = new Vec2(
                 Screen.LEFT_EDGE,


### PR DESCRIPTION
Removed a `boolean`, a `Vec2`, and a `string` from the `Affine` class, at the cost of more computation to layout the editor (though I suspect it isn't much). Longer term goal is to remove the `Affine` class entirely, but this was low hanging fruit.
